### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,37 @@
-name: Nuclino API Client
+name: Tests
 
 on: [push]
 
 jobs:
-    nuclino-api-client-tests:
-        runs-on: ubuntu-latest
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['8.1', '8.2', '8.3']
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+    name: PHP ${{ matrix.php-versions }}
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '7.4'
-                  extensions: mbstring, intl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-            - name: Install Dependencies
-              run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl
 
-            - name: Execute tests (Unit and Feature tests) via PHPUnit
-              run: |
-                  vendor/bin/phpunit
+      - name: Install Dependencies
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress
 
-            - name: Execute static analysis
-              run: |
-                  vendor/bin/phpstan
+      - name: Execute tests (Unit and Feature tests) via PHPUnit
+        run: |
+          vendor/bin/phpunit
+
+      - name: Execute static analysis
+        run: |
+          vendor/bin/phpstan
+
+      - name: Execute lint check
+        run: |
+          vendor/bin/pint --test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Please note this changelog affects this package and not the 
 Nuclino API.
 
+## [3.0.0]
+
+### Added
+
+- Add support for Laravel 11.
+- Add pint for code style.
+
+### Removed 
+
+- Drop support for PHP versions lower than 8.1
+
 ## [2.0.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Easy to use client for the API of [Nuclino](https://www.nuclino.com/).
 
 ## Requirements
 
-This package requires at least PHP 7.4.
+This package requires at least PHP 8.1.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,16 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
-        "illuminate/http": "^8.74|^9.0|^10.0",
-        "illuminate/support": "^8.22|^9.0|^10.0"
+        "illuminate/http": "^8.74|^9.0|^10.0|^11.0",
+        "illuminate/support": "^8.22|^9.0|^10.0|^11.0"
     },
     "require-dev": {
+        "laravel/pint": "^1.14",
         "phpstan/phpstan": "^1.2",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,7 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "array_indentation": false,
+        "phpdoc_align": false
+    }
+}

--- a/src/Endpoints/ItemEndpoint.php
+++ b/src/Endpoints/ItemEndpoint.php
@@ -9,10 +9,10 @@ use Vdhicts\Nuclino\Support\RequestHelper;
 trait ItemEndpoint
 {
     public function listItems(
-        string $teamId = null,
-        string $workspaceId = null,
+        ?string $teamId = null,
+        ?string $workspaceId = null,
         int $limit = 100,
-        string $after = null
+        ?string $after = null
     ): Response {
         if ($limit > 100) {
             $limit = 100;
@@ -30,8 +30,8 @@ trait ItemEndpoint
 
     public function searchItems(
         string $search,
-        string $teamId = null,
-        string $workspaceId = null,
+        ?string $teamId = null,
+        ?string $workspaceId = null,
         int $limit = 100
     ): Response {
         if ($limit > 100) {

--- a/src/Endpoints/TeamEndpoint.php
+++ b/src/Endpoints/TeamEndpoint.php
@@ -7,7 +7,7 @@ use Vdhicts\Nuclino\Support\RequestHelper;
 
 trait TeamEndpoint
 {
-    public function listTeams(int $limit = 100, string $after = null): Response
+    public function listTeams(int $limit = 100, ?string $after = null): Response
     {
         if ($limit > 100) {
             $limit = 100;

--- a/src/Endpoints/WorkspaceEndpoint.php
+++ b/src/Endpoints/WorkspaceEndpoint.php
@@ -7,7 +7,7 @@ use Vdhicts\Nuclino\Support\RequestHelper;
 
 trait WorkspaceEndpoint
 {
-    public function listWorkspaces(string $teamId = null, int $limit = 100, string $after = null): Response
+    public function listWorkspaces(?string $teamId = null, int $limit = 100, ?string $after = null): Response
     {
         if ($limit > 100) {
             $limit = 100;

--- a/src/Enum/ItemObject.php
+++ b/src/Enum/ItemObject.php
@@ -5,6 +5,7 @@ namespace Vdhicts\Nuclino\Enum;
 class ItemObject
 {
     public const ITEM = 'item';
+
     public const CLUSTER = 'cluster';
 
     public const AVAILABLE = [

--- a/src/Models/Item.php
+++ b/src/Models/Item.php
@@ -8,10 +8,15 @@ use Vdhicts\Nuclino\Enum\ItemObject;
 class Item implements Arrayable
 {
     private ?string $workspaceId = null;
+
     private ?string $parentId = null;
+
     private string $object = ItemObject::ITEM;
+
     private string $title = '';
+
     private string $content = '';
+
     private ?int $index = null;
 
     public function getWorkspaceId(): ?string

--- a/src/Nuclino.php
+++ b/src/Nuclino.php
@@ -11,14 +11,17 @@ use Vdhicts\Nuclino\Endpoints\WorkspaceEndpoint;
 
 class Nuclino extends Factory
 {
+    use FileEndpoint;
+    use ItemEndpoint;
     use TeamEndpoint;
     use WorkspaceEndpoint;
-    use ItemEndpoint;
-    use FileEndpoint;
 
     private const TIMEOUT = 180;
-    private const VERSION = '1.0.0';
-    private const USER_AGENT = 'vdhicts-nuclino-api-client/' . self::VERSION;
+
+    private const VERSION = '3.0.0';
+
+    private const USER_AGENT = 'vdhicts-nuclino-api-client/'.self::VERSION;
+
     private const BASE_URL = 'https://api.nuclino.com/';
 
     protected string $apiKey;

--- a/src/Support/RequestHelper.php
+++ b/src/Support/RequestHelper.php
@@ -13,6 +13,6 @@ class RequestHelper
             return $url;
         }
 
-        return $url . '?' . $query;
+        return $url.'?'.$query;
     }
 }

--- a/tests/Unit/NuclinoTest.php
+++ b/tests/Unit/NuclinoTest.php
@@ -23,7 +23,7 @@ class NuclinoTest extends TestCase
             return
                 $request->hasHeader('Authorization', $apiKey) &&
                 $request->hasHeader('Accept', 'application/json') &&
-                $request->url() == 'https://api.nuclino.com/v0/items/' . $id;
+                $request->url() == 'https://api.nuclino.com/v0/items/'.$id;
         });
     }
 }


### PR DESCRIPTION
# Changes

### Added

- Add support for Laravel 11.
- Add pint for code style.

### Removed 

- Drop support for PHP versions lower than 8.1

# Checks

- [x] The changelog is updated (when applicable)
- [x] The version is updated in `Client.php` (when applicable)
