### PR TITLE
Add support for Laravel 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: CI
 
 on: [push]
 
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.2', '8.3', '8.4']
 
     name: PHP ${{ matrix.php-versions }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -24,14 +24,11 @@ jobs:
       - name: Install Dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress
 
-      - name: Execute tests (Unit and Feature tests) via PHPUnit
-        run: |
-          vendor/bin/phpunit
-
       - name: Execute static analysis
-        run: |
-          vendor/bin/phpstan
+        run: composer analyse
 
-      - name: Execute lint check
-        run: |
-          vendor/bin/pint --test
+      - name: Execute tests via PHPUnit
+        run: composer test:no-coverage
+
+      - name: Check code style
+        run: composer code-style:check

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 /.idea/
 /build/
 .phpunit.result.cache
+.phpunit.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Please note this changelog affects this package and not the 
 Nuclino API.
 
+## [4.0.0]
+
+### Added
+
+- Add support for Laravel 12.
+
+### Removed
+
+- Drop support for PHP versions lower than 8.2.
+
 ## [3.0.0]
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": ">=8.2",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
-        "illuminate/http": "^8.74|^9.0|^10.0|^11.0",
-        "illuminate/support": "^8.22|^9.0|^10.0|^11.0"
+        "illuminate/http": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0"
     },
     "require-dev": {
-        "laravel/pint": "^1.14",
         "phpstan/phpstan": "^1.2",
-        "phpunit/phpunit": "^9.0|^10.0"
+        "phpunit/phpunit": "^10.0|^11.0",
+        "symplify/easy-coding-standard": "^12.3"
     },
     "autoload": {
         "psr-4": {
@@ -39,9 +39,11 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit --no-coverage",
-        "test-coverage": "vendor/bin/phpunit",
-        "analyse": "vendor/bin/phpstan"
+        "code-style:check": "vendor/bin/ecs",
+        "code-style:fix": "vendor/bin/ecs --fix",
+        "analyse": "vendor/bin/phpstan analyse",
+        "test": "vendor/bin/phpunit",
+        "test:no-coverage": "vendor/bin/phpunit --no-coverage"
     },
     "config": {
         "sort-packages": true

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\Basic\SingleLineEmptyBodyFixer;
+use PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return ECSConfig::configure()
+    ->withPaths([
+        __DIR__.'/src',
+        __DIR__.'/tests',
+    ])
+    ->withSkip([
+        SingleLineEmptyBodyFixer::class,
+        MethodArgumentSpaceFixer::class,
+    ])
+    ->withPhpCsFixerSets(perCS20: true);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <html outputDirectory="./build/report/"/>
     </report>
@@ -13,4 +10,9 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Endpoints/ItemEndpoint.php
+++ b/src/Endpoints/ItemEndpoint.php
@@ -12,7 +12,7 @@ trait ItemEndpoint
         ?string $teamId = null,
         ?string $workspaceId = null,
         int $limit = 100,
-        ?string $after = null
+        ?string $after = null,
     ): Response {
         if ($limit > 100) {
             $limit = 100;
@@ -24,7 +24,7 @@ trait ItemEndpoint
                 'workspaceId' => $workspaceId,
                 'limit' => $limit,
                 'after' => $after,
-            ])
+            ]),
         );
     }
 
@@ -32,7 +32,7 @@ trait ItemEndpoint
         string $search,
         ?string $teamId = null,
         ?string $workspaceId = null,
-        int $limit = 100
+        int $limit = 100,
     ): Response {
         if ($limit > 100) {
             $limit = 100;
@@ -44,7 +44,7 @@ trait ItemEndpoint
                 'workspaceId' => $workspaceId,
                 'limit' => $limit,
                 'search' => $search,
-            ])
+            ]),
         );
     }
 

--- a/src/Nuclino.php
+++ b/src/Nuclino.php
@@ -18,7 +18,7 @@ class Nuclino extends Factory
 
     private const TIMEOUT = 180;
 
-    private const VERSION = '3.0.0';
+    private const VERSION = '4.0.0';
 
     private const USER_AGENT = 'vdhicts-nuclino-api-client/' . self::VERSION;
 

--- a/src/Nuclino.php
+++ b/src/Nuclino.php
@@ -20,7 +20,7 @@ class Nuclino extends Factory
 
     private const VERSION = '3.0.0';
 
-    private const USER_AGENT = 'vdhicts-nuclino-api-client/'.self::VERSION;
+    private const USER_AGENT = 'vdhicts-nuclino-api-client/' . self::VERSION;
 
     private const BASE_URL = 'https://api.nuclino.com/';
 

--- a/src/Support/RequestHelper.php
+++ b/src/Support/RequestHelper.php
@@ -13,6 +13,6 @@ class RequestHelper
             return $url;
         }
 
-        return $url.'?'.$query;
+        return $url . '?' . $query;
     }
 }

--- a/tests/Unit/NuclinoTest.php
+++ b/tests/Unit/NuclinoTest.php
@@ -23,7 +23,7 @@ class NuclinoTest extends TestCase
             return
                 $request->hasHeader('Authorization', $apiKey) &&
                 $request->hasHeader('Accept', 'application/json') &&
-                $request->url() == 'https://api.nuclino.com/v0/items/'.$id;
+                $request->url() == 'https://api.nuclino.com/v0/items/' . $id;
         });
     }
 }


### PR DESCRIPTION
# Changes

### Added

- Add support for Laravel 12.

### Removed

- Drop support for PHP versions lower than 8.2.

# Checks

- [x] The changelog is updated (when applicable)
- [x] The version is updated in `Client.php` (when applicable)
